### PR TITLE
Add hybrid ATR momentum strategy and remove obsolete crypto strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,135 +2,136 @@ Universal Backtester Onboarding Guide
 Welcome to the Universal Backtester – a flexible framework for systematic trading research, rapid prototyping, and walk-forward optimization. This guide covers core data sources, built-in strategies, parameter spaces, and example workflows for fast onboarding.
 ________________________________________
 Table of Contents
-1.	Overview
-2.	Supported Data Feeds
-3.	Built-in Strategies
-o	RMA Strategy
-o	Crypto Intraday Multi-Signal
-o	SMA Cross
-o	Crypto Momentum Breakout
-4.	Parameter Spaces
-5.	Typical Use-Cases
-6.	Sample Workflow
-7.	Extending the System
-8.	Halal Compliance
-9.	FAQ & Troubleshooting
+1.    Overview
+2.    Supported Data Feeds
+3.    Built-in Strategies
+o    RMA Strategy
+o    Crypto Intraday Multi-Signal
+o    SMA Cross
+o    Crypto Hybrid ATR-Mom Break
+4.    Parameter Spaces
+5.    Typical Use-Cases
+6.    Sample Workflow
+7.    Extending the System
+8.    Halal Compliance
+9.    FAQ & Troubleshooting
 ________________________________________
 Overview
 The Universal Backtester supports multi-asset strategy research, optimization, and parameter sweeps across stocks and crypto. With built-in support for Halal (no short selling), session controls, and unified OHLCV data formatting, it's your all-in-one platform for strategy validation.
 ________________________________________
 Supported Data Feeds
-Feed Name	Loader Function	Typical Use-Case	Notes
-CSV	load_csv	Custom/historical data	Quick prototyping, local data
-Yahoo Finance	load_yfinance	US stocks, indices	Daily, 1min+, equities only
-Alpaca	load_alpaca	Stocks/crypto (live/paper)	Requires API key
-TradingView Data	load_tvdatafeed	All asset types, fast	No login = limited symbols
-TradingView TA	get_tv_ta	Technical analysis snapshot	Single-bar indicators only
-Binance	load_binance	Crypto, spot only	Direct, rate-limited
-CCXT (multi-ex)	load_ccxt	Crypto, multiple exchanges	Good for broad asset coverage
+Feed Name    Loader Function    Typical Use-Case    Notes
+CSV    load_csv    Custom/historical data    Quick prototyping, local data
+Yahoo Finance    load_yfinance    US stocks, indices    Daily, 1min+, equities only
+Alpaca    load_alpaca    Stocks/crypto (live/paper)    Requires API key
+TradingView Data    load_tvdatafeed    All asset types, fast    No login = limited symbols
+TradingView TA    get_tv_ta    Technical analysis snapshot    Single-bar indicators only
+Binance    load_binance    Crypto, spot only    Direct, rate-limited
+CCXT (multi-ex)    load_ccxt    Crypto, multiple exchanges    Good for broad asset coverage
 Note: All loaders normalize to columns: date, open, high, low, close, volume.
 ________________________________________
 Built-in Strategies
 RMA Strategy
-•	Type: Impulse/Trend-following, session aware
-•	Assets: Stocks, Crypto
-•	Halal: Long-only, no leverage
-•	Best for: Range/Trend assets, intraday and swing
+•    Type: Impulse/Trend-following, session aware
+•    Assets: Stocks, Crypto
+•    Halal: Long-only, no leverage
+•    Best for: Range/Trend assets, intraday and swing
 Crypto Intraday Multi-Signal
-•	Type: Breakout + momentum + trend + volatility filters
-•	Assets: Crypto
-•	Halal: Long-only
-•	Best for: Volatile, liquid crypto pairs
+•    Type: Breakout + momentum + trend + volatility filters
+•    Assets: Crypto
+•    Halal: Long-only
+•    Best for: Volatile, liquid crypto pairs
 SMA Cross
-•	Type: Classic Moving Average Crossover
-•	Assets: Stocks, Crypto
-•	Halal: Long-only
-•	Best for: Trend capture, simple equities systems
-Crypto Momentum Breakout
-•	Type: Simple breakout with trailing stop
-•	Assets: Crypto
-•	Halal: Long-only
-•	Best for: Strong trending crypto environments
+•    Type: Classic Moving Average Crossover
+•    Assets: Stocks, Crypto
+•    Halal: Long-only
+•    Best for: Trend capture, simple equities systems
+Crypto Hybrid ATR-Mom Break
+•    Type: ATR-based breakout with momentum confirmation
+•    Assets: Crypto
+•    Halal: Long-only
+•    Best for: Volatile crypto markets needing dynamic stops
 ________________________________________
 Parameter Spaces
 Below are the main parameter sweeps as defined in the platform (CD_PARAM_SPACES). Most strategies can be fine-tuned for your asset and timeframe.
 RMA Strategy
-Parameter	Default	Range	Step	Notes
-rma_len	50	40 to 100	5	RMA smoothing length
-barsforentry	2	1 to 10	1	Min. consecutive green bars
-barsforexit	2	1 to 10	1	Min. consecutive red bars to exit
-atrlen	9	2 to 20	1	ATR length for normalization
-normalizedupper	0.001	0 to 2	0.1	Impulse entry threshold (upper)
-normalizedlower	-0.001	0 to -2	-0.1	Impulse entry threshold (lower)
-ema_fast_len	5	2 to 30	1	Fast EMA for trend filter
-ema_slow_len	60	3 to 100	1	Slow EMA for trend filter
-emasrc	45	[15,30,45,60...]	fixed	Source EMA length
-risklen	50	40 to 0	-0.5	Stop loss in %
-trailpct	50	40 to 0	-0.5	Trailing stop in %
-Session	"13:31"-"19:52"	-	-	Session start/end (HH:MM)
-maxtradesperday	1	-	-	Maximum trades per day
+Parameter    Default    Range    Step    Notes
+rma_len    50    40 to 100    5    RMA smoothing length
+barsforentry    2    1 to 10    1    Min. consecutive green bars
+barsforexit    2    1 to 10    1    Min. consecutive red bars to exit
+atrlen    9    2 to 20    1    ATR length for normalization
+normalizedupper    0.001    0 to 2    0.1    Impulse entry threshold (upper)
+normalizedlower    -0.001    0 to -2    -0.1    Impulse entry threshold (lower)
+ema_fast_len    5    2 to 30    1    Fast EMA for trend filter
+ema_slow_len    60    3 to 100    1    Slow EMA for trend filter
+emasrc    45    [15,30,45,60...]    fixed    Source EMA length
+risklen    50    40 to 0    -0.5    Stop loss in %
+trailpct    50    40 to 0    -0.5    Trailing stop in %
+Session    "13:31"-"19:52"    -    -    Session start/end (HH:MM)
+maxtradesperday    1    -    -    Maximum trades per day
 Crypto Intraday Multi-Signal
-Parameter	Default	Range	Step
-breakout_len	20	5 to 51	5
-momentum_len	10	5 to 51	5
-momentum_thresh	0.5	0.5 to 3.0	0.3
-trend_len	50	10 to 100	1
-atr_len	14	2 to 20	1
-min_atr	0.5	0.1 to 2.1	0.2
-trailing_stop_pct	2.0	0.5 to 5.5	0.5
-max_hold_bars	3000	5 to 50	1
-maxtradesperday	20	-	-
+Parameter    Default    Range    Step
+breakout_len    20    5 to 51    5
+momentum_len    10    5 to 51    5
+momentum_thresh    0.5    0.5 to 3.0    0.3
+trend_len    50    10 to 100    1
+atr_len    14    2 to 20    1
+min_atr    0.5    0.1 to 2.1    0.2
+trailing_stop_pct    2.0    0.5 to 5.5    0.5
+max_hold_bars    3000    5 to 50    1
+maxtradesperday    20    -    -
 SMA Cross
-Parameter	Default	Range	Step
-fast_len	5	2 to 16	2
-slow_len	20	5 to 61	5
-Crypto Momentum Breakout
-Parameter	Default	Range	Step
-breakout_len	20	5-100	5
-trailing_stop_pct	2.0	0.5-5	0.5
-max_hold_bars	30	5-100	5
-maxtradesperday	20	-	-
+Parameter    Default    Range    Step
+fast_len    5    2 to 16    2
+slow_len    20    5 to 61    5
+Crypto Hybrid ATR-Mom Break
+Parameter    Default    Range    Step
+breakout_len    20    5 to 51    5
+ema_len    50    10 to 100    5
+roc_thresh    0.5    0.5 to 3.0    0.1
+atr_len    14    5 to 30    1
+atr_mult    2.0    1.0 to 3.0    0.1
 ________________________________________
 Typical Use-Cases
-•	Strategy Optimization: Use the coordinate descent optimizer to tune any parameter set for maximum Sharpe, Sortino, or profit.
-•	Walk-Forward Research: Export optimized parameter sets and apply walk-forward to test robustness on unseen data.
-•	Symbol/Timeframe Portability: Swap data source (e.g., TradingView, Alpaca, CSV) and re-use the same strategy logic across stocks or crypto.
-•	Rapid Strategy Prototyping: Add new functions and register them in STRATEGY_REGISTRY to test new alpha signals.
+•    Strategy Optimization: Use the coordinate descent optimizer to tune any parameter set for maximum Sharpe, Sortino, or profit.
+•    Walk-Forward Research: Export optimized parameter sets and apply walk-forward to test robustness on unseen data.
+•    Symbol/Timeframe Portability: Swap data source (e.g., TradingView, Alpaca, CSV) and re-use the same strategy logic across stocks or crypto.
+•    Rapid Strategy Prototyping: Add new functions and register them in STRATEGY_REGISTRY to test new alpha signals.
 ________________________________________
 Sample Workflow
-1.	Load Data
-o	Upload a CSV or connect to an API (e.g., Yahoo, Alpaca, Binance).
-o	Select symbol and timeframe.
-2.	Choose Strategy
-o	Pick from RMA, Intraday Multi-Signal, SMA Cross, or Breakout.
-o	Adjust parameter ranges as needed.
-3.	Set Backtest Range
-o	Use the date picker to filter the data for your test period.
-4.	Run Backtest
-o	Hit run and view the trade log, equity curve, and summary stats.
-5.	Optimize Parameters
-o	Use built-in optimizer for maximum return/risk-adjusted performance.
-6.	Export Results
-o	Download trade logs or parameter sets for further research or walk-forward analysis.
+1.    Load Data
+o    Upload a CSV or connect to an API (e.g., Yahoo, Alpaca, Binance).
+o    Select symbol and timeframe.
+2.    Choose Strategy
+o    Pick from RMA, Intraday Multi-Signal, SMA Cross, or Hybrid ATR-Mom Break.
+o    Adjust parameter ranges as needed.
+3.    Set Backtest Range
+o    Use the date picker to filter the data for your test period.
+4.    Run Backtest
+o    Hit run and view the trade log, equity curve, and summary stats.
+5.    Optimize Parameters
+o    Use built-in optimizer for maximum return/risk-adjusted performance.
+6.    Export Results
+o    Download trade logs or parameter sets for further research or walk-forward analysis.
 ________________________________________
 Extending the System
-•	Add a New Data Feed:
+•    Add a New Data Feed:
 Write a loader function (input: config, output: DataFrame w/ date, ohlcv) and register it in the UI.
-•	Add a New Strategy:
+•    Add a New Strategy:
 Write a function: def my_strategy(df, param1, param2, ...), return trade log DataFrame. Register in STRATEGY_REGISTRY.
-•	Custom Metrics:
+•    Custom Metrics:
 Add custom performance metrics to the summary panel for deeper analytics.
 ________________________________________
 Halal Compliance
-•	All strategies are long-only (no short selling).
-•	No margin or interest-based trading.
-•	Trade caps and risk controls to avoid excessive speculation.
+•    All strategies are long-only (no short selling).
+•    No margin or interest-based trading.
+•    Trade caps and risk controls to avoid excessive speculation.
 ________________________________________
 FAQ & Troubleshooting
-•	"No data returned" error: Check API keys, symbol names, and network.
-•	Session time filter not working: Make sure your date column is properly parsed to datetime.
-•	Strategy not taking trades: Review entry parameter ranges or check if filters are too strict.
-•	API rate limits: Use CSV or reduce frequency for high-volume data feeds.
+•    "No data returned" error: Check API keys, symbol names, and network.
+•    Session time filter not working: Make sure your date column is properly parsed to datetime.
+•    Strategy not taking trades: Review entry parameter ranges or check if filters are too strict.
+•    API rate limits: Use CSV or reduce frequency for high-volume data feeds.
 ________________________________________
 For more info, see the code comments or reach out to the maintainer. Happy backtesting!
 ________________________________________

--- a/app.py
+++ b/app.py
@@ -11,13 +11,8 @@ from numpy.matlib import empty
 from datafeed import (load_csv, load_yfinance, load_alpaca, load_tvdatafeed, get_tv_ta, load_ccxt)
 from strategies.rma import rma_strategy
 from strategies.sma_cross import sma_cross_strategy
-from strategies.crypto_momentum_breakout import momentum_breakout_strategy
-from strategies.crypto_mean_reversion import mean_reversion_strategy
-from strategies.crypto_ma_cross import ma_cross_strategy
-from strategies.crypto_volatility_breakout import volatility_breakout_strategy
-from strategies.crypto_pairs_trading import pairs_trading_strategy
-from strategies.crypto_volume_price_action import volume_price_action_strategy
 from strategies.crypto_intraday_multi import crypto_intraday_multi
+from strategies.hybrid_atr_mom_break import hybrid_atr_momentum_breakout
 from alpaca.trading.client import TradingClient
 from alpaca.trading.enums import AssetClass
 
@@ -143,35 +138,11 @@ STRATEGY_REGISTRY = {
         ],
         "universal": ["initial_capital", "qty"]
     },
-    "Crypto Momentum Breakout": {
-        "function": momentum_breakout_strategy,
-        "params": ["lookback"],
-        "universal": ["initial_capital", "qty"]
-    },
-    "Crypto Mean Reversion": {
-        "function": mean_reversion_strategy,
-        "params": ["ma_len", "threshold"],
-        "universal": ["initial_capital", "qty"]
-    },
-    "Crypto MA Cross": {
-        "function": ma_cross_strategy,
-        "params": ["fast_len", "slow_len"],
-        "universal": ["initial_capital", "qty"]
-    },
-    "Crypto Volatility Breakout": {
-        "function": volatility_breakout_strategy,
-        "params": ["atr_len", "mult"],
-        "universal": ["initial_capital", "qty"]
-    },
-    "Crypto Pairs Trading": {
-        "function": pairs_trading_strategy,
-        "params": ["spread_lookback", "threshold"],
-        "universal": ["qty"]
-        # Note: expects two dataframes: df1, df2
-    },
-    "Crypto Volume Price Action": {
-        "function": volume_price_action_strategy,
-        "params": ["ma_len", "vol_mult"],
+    "Crypto Hybrid ATR-Mom Break": {
+        "function": hybrid_atr_momentum_breakout,
+        "params": [
+            "breakout_len", "ema_len", "roc_thresh", "atr_len", "atr_mult"
+        ],
         "universal": ["initial_capital", "qty"]
     }
 }
@@ -182,12 +153,7 @@ CRYPTO_DISABLE_IN_OPT = ["maxtradesperday", "session_start", "session_end", "ini
 # For convenience, you can add this to each crypto strategy registry entry if you want per-strategy overrides
 CRYPTO_STRATEGY_KEYS = [
     "Crypto Intraday Multi-Signal",
-    "Crypto Momentum Breakout",
-    "Crypto Mean Reversion",
-    "Crypto MA Cross",
-    "Crypto Volatility Breakout",
-    "Crypto Pairs Trading",
-    "Crypto Volume Price Action"
+    "Crypto Hybrid ATR-Mom Break"
 ]
 
 # --- Per-strategy parameter search spaces for coordinate descent
@@ -217,28 +183,12 @@ CD_PARAM_SPACES = {
         "fast_len": (2, 16, 2),
         "slow_len": (5, 61, 5)
     },
-    "Crypto Momentum Breakout": {
-        "lookback": (10, 50, 2)
-    },
-    "Crypto Mean Reversion": {
-        "ma_len": (10, 60, 2),
-        "threshold": (1, 4, 0.2)
-    },
-    "Crypto MA Cross": {
-        "fast_len": (2, 20, 2),
-        "slow_len": (5, 60, 5)
-    },
-    "Crypto Volatility Breakout": {
-        "atr_len": (5, 30, 2),
-        "mult": (1.0, 3.0, 0.2)
-    },
-    "Crypto Pairs Trading": {
-        "spread_lookback": (10, 60, 5),
-        "threshold": (1.0, 3.0, 0.2)
-    },
-    "Crypto Volume Price Action": {
-        "ma_len": (10, 60, 2),
-        "vol_mult": (1.2, 4.0, 0.2)
+    "Crypto Hybrid ATR-Mom Break": {
+        "breakout_len": (5, 51, 5),
+        "ema_len": (10, 100, 5),
+        "roc_thresh": (0.5, 3.0, 0.1),
+        "atr_len": (5, 30, 1),
+        "atr_mult": (1.0, 3.0, 0.1)
     }
 }
 

--- a/app_working.py
+++ b/app_working.py
@@ -11,13 +11,8 @@ from numpy.matlib import empty
 from datafeed import (load_csv, load_yfinance, load_alpaca, load_tvdatafeed, get_tv_ta, load_ccxt)
 from strategies.rma import rma_strategy
 from strategies.sma_cross import sma_cross_strategy
-from strategies.crypto_momentum_breakout import momentum_breakout_strategy
-from strategies.crypto_mean_reversion import mean_reversion_strategy
-from strategies.crypto_ma_cross import ma_cross_strategy
-from strategies.crypto_volatility_breakout import volatility_breakout_strategy
-from strategies.crypto_pairs_trading import pairs_trading_strategy
-from strategies.crypto_volume_price_action import volume_price_action_strategy
 from strategies.crypto_intraday_multi import crypto_intraday_multi
+from strategies.hybrid_atr_mom_break import hybrid_atr_momentum_breakout
 from alpaca.trading.client import TradingClient
 from alpaca.trading.enums import AssetClass
 
@@ -141,35 +136,11 @@ STRATEGY_REGISTRY = {
         ],
         "universal": []
     },
-    "Crypto Momentum Breakout": {
-        "function": momentum_breakout_strategy,
-        "params": ["lookback"],
-        "universal": []
-    },
-    "Crypto Mean Reversion": {
-        "function": mean_reversion_strategy,
-        "params": ["ma_len", "threshold"],
-        "universal": []
-    },
-    "Crypto MA Cross": {
-        "function": ma_cross_strategy,
-        "params": ["fast_len", "slow_len"],
-        "universal": []
-    },
-    "Crypto Volatility Breakout": {
-        "function": volatility_breakout_strategy,
-        "params": ["atr_len", "mult"],
-        "universal": []
-    },
-    "Crypto Pairs Trading": {
-        "function": pairs_trading_strategy,
-        "params": ["spread_lookback", "threshold"],
-        "universal": []
-        # Note: expects two dataframes: df1, df2
-    },
-    "Crypto Volume Price Action": {
-        "function": volume_price_action_strategy,
-        "params": ["ma_len", "vol_mult"],
+    "Crypto Hybrid ATR-Mom Break": {
+        "function": hybrid_atr_momentum_breakout,
+        "params": [
+            "breakout_len", "ema_len", "roc_thresh", "atr_len", "atr_mult"
+        ],
         "universal": []
     }
 }
@@ -180,12 +151,7 @@ CRYPTO_DISABLE_IN_OPT = ["maxtradesperday", "session_start", "session_end", "ini
 # For convenience, you can add this to each crypto strategy registry entry if you want per-strategy overrides
 CRYPTO_STRATEGY_KEYS = [
     "Crypto Intraday Multi-Signal",
-    "Crypto Momentum Breakout",
-    "Crypto Mean Reversion",
-    "Crypto MA Cross",
-    "Crypto Volatility Breakout",
-    "Crypto Pairs Trading",
-    "Crypto Volume Price Action"
+    "Crypto Hybrid ATR-Mom Break"
 ]
 
 # --- Per-strategy parameter search spaces for coordinate descent
@@ -215,28 +181,12 @@ CD_PARAM_SPACES = {
         "fast_len": (2, 16, 2),
         "slow_len": (5, 61, 5)
     },
-    "Crypto Momentum Breakout": {
-        "lookback": (10, 50, 2)
-    },
-    "Crypto Mean Reversion": {
-        "ma_len": (10, 60, 2),
-        "threshold": (1, 4, 0.2)
-    },
-    "Crypto MA Cross": {
-        "fast_len": (2, 20, 2),
-        "slow_len": (5, 60, 5)
-    },
-    "Crypto Volatility Breakout": {
-        "atr_len": (5, 30, 2),
-        "mult": (1.0, 3.0, 0.2)
-    },
-    "Crypto Pairs Trading": {
-        "spread_lookback": (10, 60, 5),
-        "threshold": (1.0, 3.0, 0.2)
-    },
-    "Crypto Volume Price Action": {
-        "ma_len": (10, 60, 2),
-        "vol_mult": (1.2, 4.0, 0.2)
+    "Crypto Hybrid ATR-Mom Break": {
+        "breakout_len": (5, 51, 5),
+        "ema_len": (10, 100, 5),
+        "roc_thresh": (0.5, 3.0, 0.1),
+        "atr_len": (5, 30, 1),
+        "atr_mult": (1.0, 3.0, 0.1)
     }
 }
 

--- a/registry.py
+++ b/registry.py
@@ -2,12 +2,8 @@
 
 from strategies.rma import rma_strategy
 from strategies.sma_cross import sma_cross_strategy
-from strategies.crypto_momentum_breakout import momentum_breakout_strategy
-from strategies.crypto_mean_reversion import mean_reversion_strategy
-from strategies.crypto_ma_cross import ma_cross_strategy
-from strategies.crypto_volatility_breakout import volatility_breakout_strategy
-from strategies.crypto_volume_price_action import volume_price_action_strategy
 from strategies.crypto_intraday_multi import crypto_intraday_multi
+from strategies.hybrid_atr_mom_break import hybrid_atr_momentum_breakout
 
 STRATEGY_REGISTRY = {
     "RMA Strategy": {
@@ -33,29 +29,9 @@ STRATEGY_REGISTRY = {
         "params": ["fast_len", "slow_len"],
         "universal": ["qty"]
     },
-    "Crypto Momentum Breakout": {
-        "function": momentum_breakout_strategy,
-        "params": ["lookback"],
-        "universal": ["qty"]
-    },
-    "Crypto Mean Reversion": {
-        "function": mean_reversion_strategy,
-        "params": ["ma_len", "threshold"],
-        "universal": ["qty"]
-    },
-    "Crypto MA Cross": {
-        "function": ma_cross_strategy,
-        "params": ["fast_len", "slow_len"],
-        "universal": ["qty"]
-    },
-    "Crypto Volatility Breakout": {
-        "function": volatility_breakout_strategy,
-        "params": ["atr_len", "mult"],
-        "universal": ["qty"]
-    },
-    "Crypto Volume Price Action": {
-        "function": volume_price_action_strategy,
-        "params": ["ma_len", "vol_mult"],
+    "Crypto Hybrid ATR-Mom Break": {
+        "function": hybrid_atr_momentum_breakout,
+        "params": ["breakout_len", "ema_len", "roc_thresh", "atr_len", "atr_mult"],
         "universal": ["qty"]
     },
 }
@@ -66,11 +42,7 @@ CRYPTO_DISABLE_IN_OPT = ["session_start", "session_end", "initial_capital"]
 # Order of crypto strategies shown in any crypto-specific lists/loops
 CRYPTO_STRATEGY_KEYS = [
     "Crypto Intraday Multi-Signal",
-    "Crypto Momentum Breakout",
-    "Crypto Mean Reversion",
-    "Crypto MA Cross",
-    "Crypto Volatility Breakout",
-    "Crypto Volume Price Action",
+    "Crypto Hybrid ATR-Mom Break",
 ]
 
 # Coordinate Descent parameter spaces per strategy
@@ -97,9 +69,11 @@ CD_PARAM_SPACES = {
         "max_hold_bars": (5, 50, 1),
     },
     "SMA Cross": {"fast_len": (2, 16, 2), "slow_len": (5, 61, 5)},
-    "Crypto Momentum Breakout": {"lookback": (10, 50, 2)},
-    "Crypto Mean Reversion": {"ma_len": (10, 60, 2), "threshold": (1, 4, 0.2)},
-    "Crypto MA Cross": {"fast_len": (2, 20, 2), "slow_len": (5, 60, 5)},
-    "Crypto Volatility Breakout": {"atr_len": (5, 30, 2), "mult": (1.0, 3.0, 0.2)},
-    "Crypto Volume Price Action": {"ma_len": (10, 60, 2), "vol_mult": (1.2, 4.0, 0.2)},
+    "Crypto Hybrid ATR-Mom Break": {
+        "breakout_len": (5, 51, 5),
+        "ema_len": (10, 100, 5),
+        "roc_thresh": (0.5, 3.0, 0.1),
+        "atr_len": (5, 30, 1),
+        "atr_mult": (1.0, 3.0, 0.1),
+    },
 }


### PR DESCRIPTION
## Summary
- add Hybrid ATR-Mom Break strategy to app and registry
- drop unused crypto strategies and update strategy lists and parameter spaces
- document new strategy and remove old ones in README

## Testing
- `python -m py_compile app.py app_working.py registry.py`


------
https://chatgpt.com/codex/tasks/task_e_68998fafe01c8333b679e7ec86008a80